### PR TITLE
Loads entire history at once

### DIFF
--- a/www/components/File.tsx
+++ b/www/components/File.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from "react";
 import { repo, owner, octokit } from "@/config/octokit";
 import DiffContainer from "./DiffContainer";
-import { FaBeer } from "react-icons/fa";
 import { format } from "date-fns";
 
 interface Sha {
@@ -25,7 +24,30 @@ const File: React.FC<Props> = ({ commits, path, commentCount, setLoading }) => {
   const [commitData, setCommitData] = useState<any>({});
   const [content, setContent] = useState<any>([]);
 
+  const getUniqueCommits = (commits: any) => {
+    let uniqueCommits: Array<string> = [];
+    for (const commit of commits) {
+      if (uniqueCommits.includes(commit.firstElement) || !commit.firstElement) {
+        continue;
+      } else {
+        uniqueCommits.push(commit.firstElement);
+      }
+
+      if (
+        uniqueCommits.includes(commit.secondElement) || !commit.secondElement
+      ) {
+        continue;
+      } else {
+        uniqueCommits.push(commit.secondElement);
+      }
+    }
+    return uniqueCommits;
+  }
+  const a = getUniqueCommits(commits);
+  console.log(a);
+
   const getCommitData = async (commitRef: any) => {
+    console.log(`Getting `)
     // Do not send a request if the data exists
     if (commitData[commitRef]) {
       console.log(`Cache found for ${commitRef}`)
@@ -83,7 +105,7 @@ const File: React.FC<Props> = ({ commits, path, commentCount, setLoading }) => {
       }
       setLoading(false);
     };
-    fetchData();
+    // fetchData();
   }, [commentCount]);
   return (
     <div>

--- a/www/components/File.tsx
+++ b/www/components/File.tsx
@@ -25,13 +25,13 @@ const File: React.FC<Props> = ({ commits, path, commentCount, setLoading }) => {
   const [content, setContent] = useState<any>([]);
 
   useEffect(() => {
-    const makeReq = async () => {
+    const makeReq = async (commit: any) => {
       setLoading(true);
       const firstVersion: any = await octokit.rest.repos.getContent({
         owner,
         repo,
         path,
-        ref: commits[commentCount].firstElement,
+        ref: commit.firstElement,
       });
 
       const firstVersionContent = Buffer.from(
@@ -40,12 +40,12 @@ const File: React.FC<Props> = ({ commits, path, commentCount, setLoading }) => {
       ).toString();
 
       let secondVersionContent = "";
-      if (commits[commentCount].secondElement) {
+      if (commit.secondElement) {
         const secondVersion: any = await octokit.rest.repos.getContent({
           owner,
           repo,
           path,
-          ref: commits[commentCount].secondElement,
+          ref: commit.secondElement,
         });
 
         secondVersionContent = Buffer.from(
@@ -57,12 +57,15 @@ const File: React.FC<Props> = ({ commits, path, commentCount, setLoading }) => {
       return {
         current: firstVersionContent,
         previous: secondVersionContent,
-        commits: commits[commentCount],
+        commits: commit,
       };
     };
     const fetchData = async () => {
-      const data = await makeReq();
-      setContent([...content, data]);
+      for (const commit of commits) {
+        const data = await makeReq(commit);
+        setContent([...content, data]);
+      }
+      console.log(content);
       setLoading(false);
     };
     fetchData();

--- a/www/components/File.tsx
+++ b/www/components/File.tsx
@@ -64,17 +64,12 @@ const File: React.FC<Props> = ({ commits, path, commentCount, setLoading }) => {
 
     const getChangesData = async (commits: any, allCommitsRes: any) => {
       for (const commit of commits) {
-        console.log(`Getting data for ${commit.firstElement}`);
-
-        const relatedCommit = allCommitsRes.filter(
+        const relatedCommit = allCommitsRes.find(
           (res: { data: { url: string } }) => {
-            console.log(res.data.url)
-            return true;
+            return res?.data?.url.includes(commit.firstElement);
           }
         );
         console.log(relatedCommit);
-        const firstVersion: any = allCommitsRes[1].data.url;
-        console.log(firstVersion);
       }
 
         // const firstVersionContent = Buffer.from(

--- a/www/components/FileHistory.tsx
+++ b/www/components/FileHistory.tsx
@@ -12,26 +12,17 @@ interface Props {
 }
 
 const FileHistory: React.FC<Props> = ({ path, commentsShaArray }) => {
-  const [showChange, setShowChange] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [commentCount, setCommitCount] = useState(0);
-
-  const loadDetailsHandler = async () => {
-    if (commentCount < 1) {
-      setShowChange(true);
-    }
-    setCommitCount((num) => num + 1);
-  };
 
   return (
     <section>
-      {showChange && (
+      {showHistory && (
         <div>
           <h1 className="text-green-600 font-bold  mt-4">File History</h1>
           <File
             commits={commentsShaArray}
             path={path}
-            commentCount={commentCount}
             setLoading={setLoading}
           />
         </div>
@@ -40,12 +31,12 @@ const FileHistory: React.FC<Props> = ({ path, commentsShaArray }) => {
       {loading && <Loading />}
 
       <div className="flex justify-center  my-4 ">
-        {commentsShaArray.length > 1 && !showChange ? (
+        {commentsShaArray.length > 1 && !showHistory ? (
           <button
             className="py-2 px-8 border text-sm border-green-600 font-bold text-green-600 rounded-md bg-white"
-            onClick={loadDetailsHandler}
+            onClick={() => setShowHistory(true)}
           >
-            Load Details
+            Load entry history
           </button>
         ) : null}
       </div>

--- a/www/components/FileHistory.tsx
+++ b/www/components/FileHistory.tsx
@@ -40,14 +40,14 @@ const FileHistory: React.FC<Props> = ({ path, commentsShaArray }) => {
       {loading && <Loading />}
 
       <div className="flex justify-center  my-4 ">
-        {commentsShaArray.length < commentCount + 2 ? null : (
+        {commentsShaArray.length > 1 && !showChange ? (
           <button
             className="py-2 px-8 border text-sm border-green-600 font-bold text-green-600 rounded-md bg-white"
             onClick={loadDetailsHandler}
           >
             Load Details
           </button>
-        )}
+        ) : null}
       </div>
     </section>
   );


### PR DESCRIPTION
Fixes #23

~~So far the commit data is replacing the state after request finishes. Needs to be fixed~~

To be added: caching requests so that it doesn't send the same one twice